### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ install:
 - conda install python=$TRAVIS_PYTHON_VERSION
 - conda install -q conda-build anaconda-client coverage sphinx
 script:
-- conda build ./recipe -c csdms-stack -c conda-forge
+- conda build ./recipe -c csdms-stack -c conda-forge --old-build-string
 after_success:
-- curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py
-  > $HOME/anaconda_upload.py
-- echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack
-  --token=-
+- curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
+- echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ test:
     - pymt
 
 build:
-  number: 3
+  number: 4
 
 about:
   home: http://csdms.colorado.edu/wiki/Model:CHILD

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ requirements:
   build:
     - bmi-babel
     - child
-    - pymt
   run:
     - bmi-babel
     - child
+    - matplotlib
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,11 @@ requirements:
   build:
     - bmi-babel
     - child
+    - scipy <=0.18.1
   run:
     - bmi-babel
     - child
+    - scipy <=0.18.1
     - matplotlib
 
 test:


### PR DESCRIPTION
This PR fixes this recipe, which had been failing for a few weeks. The changes I've made are similar to those in https://github.com/csdms-stack/permamodel-ku-csdms-recipe/pull/3:

* add matplotlib to run dependencies
* limit scipy version to <=0.18.1
* remove build has from filename

I think the scipy update from 0.18.1 to 0.19.1 is the major culprit.